### PR TITLE
Events

### DIFF
--- a/loefsys/events/admin.py
+++ b/loefsys/events/admin.py
@@ -22,7 +22,7 @@ class RegistrationFormInline(admin.TabularInline):
     """Inline admin interface for registration form fields."""
 
     model = RegistrationFormField
-    extra = 1
+    extra = 0
 
 
 class EventOrganizerInline(admin.TabularInline):

--- a/loefsys/events/forms.py
+++ b/loefsys/events/forms.py
@@ -20,7 +20,10 @@ class EventFieldsForm(forms.Form):
                 case RegistrationFormField.INTEGER_FIELD:
                     self.fields[key] = forms.IntegerField(required=field["required"])
                 case RegistrationFormField.DATETIME_FIELD:
-                    self.fields[key] = forms.DateTimeField(required=field["required"])
+                    self.fields[key] = forms.DateTimeField(
+                        required=field["required"],
+                        widget=forms.DateTimeInput(attrs={"type": "datetime-local"}),
+                    )
                 case _:  # RegistrationFormField.TEXT_FIELD
                     self.fields[key] = forms.CharField(
                         required=field["required"],
@@ -36,7 +39,9 @@ class EventFieldsForm(forms.Form):
 
             self.fields[key].label = field["subject"]
             self.fields[key].help_text = field["description"]
-            self.fields[key].initial = field["default"]
+            self.fields[key].initial = (
+                field["value"] if field["value"] else field["default"]
+            )
 
     def field_values(self):
         """Get field values."""

--- a/loefsys/events/forms.py
+++ b/loefsys/events/forms.py
@@ -12,7 +12,8 @@ class EventFieldsForm(forms.Form):
         self.form_fields = kwargs.pop("form_fields")
         super().__init__(*args, **kwargs)
 
-        for key, field in self.form_fields:
+        for k, field in self.form_fields:
+            key = str(k)
             match field["type"]:
                 case RegistrationFormField.BOOLEAN_FIELD:
                     self.fields[key] = forms.BooleanField(required=False)
@@ -43,4 +44,4 @@ class EventFieldsForm(forms.Form):
         print("cleaned_data", self.cleaned_data)
         for pk, field in self.form_fields:
             registration_form_field = RegistrationFormField.objects.get(id=pk)
-            yield pk, self.data.get(str(pk), registration_form_field.default)
+            yield pk, self.cleaned_data.get(str(pk), registration_form_field.default)

--- a/loefsys/events/models/registration_form_field.py
+++ b/loefsys/events/models/registration_form_field.py
@@ -88,9 +88,6 @@ class RegistrationFormField(models.Model):
         """Set value for registration form field based on registration and value."""
         value_set = self.__get_field_set()
 
-        if self.type == self.BOOLEAN_FIELD:
-            value = True if value == "on" else False
-
         try:
             field_value = value_set.get(registration=registration)
         except BooleanRegistrationInformation.DoesNotExist:

--- a/loefsys/events/templates/events/event.html
+++ b/loefsys/events/templates/events/event.html
@@ -69,6 +69,11 @@
                     document.getElementById("fine-consent-checkbox").type="checkbox"
                 }
             </script>
+            {% if event.has_form_fields %}
+            <a href="{% url 'events:registration' slug=event.slug %}">
+                <button>Wijzig formulier</button>
+            </a>
+            {% endif %}
         </div>
         {% else %}
         <div class="border p-4 rounded-xl bg-gray-100 justify-center mt-4">

--- a/loefsys/events/views.py
+++ b/loefsys/events/views.py
@@ -159,7 +159,7 @@ class RegistrationFormView(FormView):
         return kwargs
 
     def form_valid(self, form):
-        """Check if form is valid."""
+        """Handle valid form."""
         values = form.field_values()
         registration = self.__get_registration(self.event, self.request.user)
 

--- a/loefsys/events/views.py
+++ b/loefsys/events/views.py
@@ -2,6 +2,7 @@
 
 from django.db import IntegrityError
 from django.db.models import Q
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -26,6 +27,9 @@ class EventView(DetailView):
         The template needs these variables to render the correct page.
         (E.g. whether to render the registration or cancellation button.)
         """
+        if not self.get_object().published:
+            raise Http404("Not found")
+
         context = super().get_context_data(**kwargs)
         context["registration_active"] = (
             self.get_registrations_for_current_user().count() > 0


### PR DESCRIPTION
- Fixes #57 
- Added date time picker to datetime field (for now)
- When showing the form, already filled in values are present (if user already submitted the form before)
- Added button that leads to form submission page from the event details page
- 404 page when trying to view details page for event that is not published
- Docstring fix
- Small admin page change
- Now that #57 works, added tests to see if required form fields work properly. Also modified the other tests slightly to be more robust